### PR TITLE
Export type CazooLogger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {useHttpRecorder, HttpRecorder} from './httpRequest';
 
 import {AnyEvent, contextFactory, LambdaContext} from './aws';
 
-type CazooLogger = Logger &
+export type CazooLogger = Logger &
   TimeoutLogger &
   FluentContext &
   EventRecorder &


### PR DESCRIPTION
Previously we used the exported type `Logger` to cast a mock Cazoo logger using `as`.
But now the new logger type is `CazooLogger` but it is not exported.
Can we export `CazooLogger`?

![image](https://user-images.githubusercontent.com/10026538/104303178-aa72be80-54c1-11eb-8654-b7d0b9802b61.png)


![image](https://user-images.githubusercontent.com/10026538/104303005-6aabd700-54c1-11eb-9006-1b13dc3649bd.png)

Now working with exported `CazooLogger`

![image](https://user-images.githubusercontent.com/10026538/104303425-fde50c80-54c1-11eb-9a94-e121812f6f74.png)

![image](https://user-images.githubusercontent.com/10026538/104303390-f160b400-54c1-11eb-8e85-81ceec56aafe.png)
